### PR TITLE
MULE-13419: Avoid exporting exception mappings and property editor

### DIFF
--- a/module/src/main/resources/META-INF/mule-artifact.json
+++ b/module/src/main/resources/META-INF/mule-artifact.json
@@ -35,8 +35,7 @@
       ],
       "exportedResources":[
         "META-INF/mule.schemas",
-        "META-INF/mule-spring.xsd",
-        "META-INF/mule.custom-property-editors"
+        "META-INF/mule-spring.xsd"
       ]
     }
   }


### PR DESCRIPTION
resources