### PR TITLE
MULE-13132: Add support to access privileged API class from test case

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -84,6 +84,12 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${springVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
             <version>${springVersion}</version>
             <scope>test</scope>
@@ -91,6 +97,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${springVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
             <version>${springVersion}</version>
             <scope>test</scope>
         </dependency>
@@ -104,6 +116,12 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
             <version>${springSecurityVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mule.tests</groupId>
+            <artifactId>mule-tests-model</artifactId>
+            <version>${mule.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/src/test/java/org/mule/extension/spring/test/PlaceholderTestCase.java
+++ b/tests/src/test/java/org/mule/extension/spring/test/PlaceholderTestCase.java
@@ -8,19 +8,17 @@ package org.mule.extension.spring.test;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.mule.extension.spring.AllureConstants.SpringFeature.SPRING_EXTENSION;
 import static org.mule.extension.spring.AllureConstants.SpringFeature.ArtifactAndSpringModuleInteroperabilityStory.ARTIFACT_AND_SPRING_MODULE_INTEROPERABILITY;
-
+import static org.mule.extension.spring.AllureConstants.SpringFeature.SPRING_EXTENSION;
 import org.mule.tck.junit4.rule.SystemProperty;
 import org.mule.tck.testmodels.fruit.Orange;
-
-import org.junit.Rule;
-import org.junit.Test;
 
 import java.util.Map;
 
 import io.qameta.allure.Feature;
 import io.qameta.allure.Story;
+import org.junit.Rule;
+import org.junit.Test;
 
 @Feature(SPRING_EXTENSION)
 @Story(ARTIFACT_AND_SPRING_MODULE_INTEROPERABILITY)

--- a/tests/src/test/java/org/mule/extension/spring/test/SpringPluginFunctionalTestCase.java
+++ b/tests/src/test/java/org/mule/extension/spring/test/SpringPluginFunctionalTestCase.java
@@ -9,11 +9,14 @@ package org.mule.extension.spring.test;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
 
-@ArtifactClassLoaderRunnerConfig(sharedRuntimeLibs = {
-    "org.mule.tests:mule-tests-unit",
+@ArtifactClassLoaderRunnerConfig(applicationSharedRuntimeLibs = {
+    "org.springframework:spring-core",
     "org.springframework:spring-beans",
     "org.springframework:spring-context",
-    "org.springframework.security:spring-security-core"
+    "org.springframework:spring-aop",
+    "org.springframework.security:spring-security-core",
+    "org.springframework.security:spring-security-config",
+    "org.mule.tests:mule-tests-model"
 })
 public abstract class SpringPluginFunctionalTestCase extends MuleArtifactFunctionalTestCase {
 }


### PR DESCRIPTION
_ Adding a test-runner plugin to contain test code and access privileged APIs
_ Application's context is created using the application classloader
_ Test is executed using test runner classloader
_ Adding runner configuration attribute to set application libraries (not visible to plugins)
_ Adding runner configuration attribute to set exported libraries from the test runner
_ Extracting mule-test-model artifact form mule-test-unit to contain all the classes that are used from different plugins and needs to be shared from the application
_ Enabling defining mule modules with privileged exported packages but no privileges artifacts