### PR TITLE
W-11676834 update dependency versions

### DIFF
--- a/module/src/main/java/org/mule/extension/spring/internal/SpringModuleExtensionModelGenerator.java
+++ b/module/src/main/java/org/mule/extension/spring/internal/SpringModuleExtensionModelGenerator.java
@@ -64,8 +64,8 @@ public class SpringModuleExtensionModelGenerator implements ExtensionLoadingDele
   private static final String UNESCAPED_LOCATION_PREFIX = "http://";
   private static final String SCHEMA_LOCATION = "www.mulesoft.org/schema/mule/spring";
   private static final String SCHEMA_VERSION = "current";
-  private static final String SPRING_VERSION = "5.3.15";
-  private static final String SPRING_SECURITY_VERSION = "5.6.1";
+  private static final String SPRING_VERSION = "5.3.22";
+  private static final String SPRING_SECURITY_VERSION = "5.7.3";
   private static final String SPRING_GROUP_ID = "org.springframework";
   private static final String SPRING_SECURITY_GROUP_ID = "org.springframework.security";
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,14 @@
     <name>Spring Module</name>
     <packaging>pom</packaging>
     <version>1.4.0-SNAPSHOT</version>
+    
 
     <properties>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
-        <springVersion>5.3.15</springVersion>
-        <springSecurityVersion>5.6.1</springSecurityVersion>
+        <springVersion>5.3.22</springVersion>
+        <springSecurityVersion>5.7.3</springSecurityVersion>
         <mule.version>4.1.5</mule.version>
+        <gsonVersion>2.9.1</gsonVersion>
     </properties>
 
     <modules>
@@ -25,6 +27,62 @@
         <module>tests</module>
         <module>test-plugin</module>
     </modules>
+
+	<dependencyManagement>
+	    <dependencies>
+	        <dependency>
+	            <artifactId>mule-api</artifactId>
+	            <groupId>org.mule.runtime</groupId>
+	            <version>1.1.1</version>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <artifactId>mule-metadata-model-json</artifactId>
+	            <groupId>org.mule.runtime</groupId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <groupId>org.mule.runtime</groupId>
+            	<artifactId>mule-module-service</artifactId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <groupId>org.mule.runtime</groupId>
+            	<artifactId>mule-module-extensions-spring-support</artifactId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <groupId>org.mule.runtime</groupId>
+            	<artifactId>mule-extensions-api-persistence</artifactId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	    </dependencies>
+	</dependencyManagement>
 
     <distributionManagement>
         <downloadUrl>http://www.mulesoft.org/display/MULE/Download</downloadUrl>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,6 +21,13 @@
             <version>${mule.api.version}</version>
         </dependency>
 
+		<dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gsonVersion}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mule-spring-module</artifactId>


### PR DESCRIPTION
update version for spring and spring security. 
exclude gson from transitive dependency 
update version test case

- Bump com.google.code.gson to v 2.9.1
- Bump org.springframework to v 5.3.22
- Bump org.springframework.security to 5.7.3 