### PR TITLE
W-11676834-1.3.x: Update version for spring, spring security.

### DIFF
--- a/module/pom.xml
+++ b/module/pom.xml
@@ -75,6 +75,12 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${springSecurityVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
             <version>${springSecurityVersion}</version>
             <scope>provided</scope>

--- a/module/src/main/java/org/mule/extension/spring/internal/SpringModuleExtensionModelGenerator.java
+++ b/module/src/main/java/org/mule/extension/spring/internal/SpringModuleExtensionModelGenerator.java
@@ -64,8 +64,8 @@ public class SpringModuleExtensionModelGenerator implements ExtensionLoadingDele
   private static final String UNESCAPED_LOCATION_PREFIX = "http://";
   private static final String SCHEMA_LOCATION = "www.mulesoft.org/schema/mule/spring";
   private static final String SCHEMA_VERSION = "current";
-  private static final String SPRING_VERSION = "5.3.2";
-  private static final String SPRING_SECURITY_VERSION = "5.4.2";
+  private static final String SPRING_VERSION = "5.3.22";
+  private static final String SPRING_SECURITY_VERSION = "5.7.3";
   private static final String SPRING_GROUP_ID = "org.springframework";
   private static final String SPRING_SECURITY_GROUP_ID = "org.springframework.security";
 
@@ -221,6 +221,12 @@ public class SpringModuleExtensionModelGenerator implements ExtensionLoadingDele
     extensionDeclarer.withExternalLibrary(ExternalLibraryModel.builder()
         .withName("Spring Security Core")
         .withCoordinates(SPRING_SECURITY_GROUP_ID + ":spring-security-core:" + SPRING_SECURITY_VERSION)
+        .withDescription("Spring Security Context (http://spring.io/spring-security). Based on the application usage of the Spring Framework, other spring/spring-security dependencies may be required.")
+        .withType(DEPENDENCY).build());
+
+    extensionDeclarer.withExternalLibrary(ExternalLibraryModel.builder()
+        .withName("Spring Security Crypto")
+        .withCoordinates(SPRING_SECURITY_GROUP_ID + ":spring-security-crypto:" + SPRING_SECURITY_VERSION)
         .withDescription("Spring Security Context (http://spring.io/spring-security). Based on the application usage of the Spring Framework, other spring/spring-security dependencies may be required.")
         .withType(DEPENDENCY).build());
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,10 @@
 
     <properties>
         <formatterConfigPath>formatter.xml</formatterConfigPath>
-        <springVersion>5.3.2</springVersion>
-        <springSecurityVersion>5.4.2</springSecurityVersion>
+        <springVersion>5.3.22</springVersion>
+        <springSecurityVersion>5.7.3</springSecurityVersion>
         <mule.version>4.1.5</mule.version>
+        <gsonVersion>2.9.1</gsonVersion>
     </properties>
 
     <modules>
@@ -25,6 +26,67 @@
         <module>tests</module>
         <module>test-plugin</module>
     </modules>
+
+	<dependencyManagement>
+	    <dependencies>
+	        <dependency>
+	            <artifactId>mule-api</artifactId>
+	            <groupId>org.mule.runtime</groupId>
+	            <version>1.1.1</version>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <artifactId>mule-metadata-model-json</artifactId>
+	            <groupId>org.mule.runtime</groupId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <groupId>org.mule.runtime</groupId>
+            	<artifactId>mule-module-service</artifactId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <groupId>org.mule.runtime</groupId>
+            	<artifactId>mule-module-extensions-spring-support</artifactId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+	            <groupId>org.mule.runtime</groupId>
+            	<artifactId>mule-extensions-api-persistence</artifactId>
+	            <exclusions>
+	                <exclusion>
+	                    <groupId>com.google.code.gson</groupId>
+	                    <artifactId>gson</artifactId>
+	                </exclusion>
+	            </exclusions>
+	        </dependency>
+	        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${springSecurityVersion}</version>
+        </dependency>
+	    </dependencies>
+	</dependencyManagement>
 
     <distributionManagement>
         <downloadUrl>http://www.mulesoft.org/display/MULE/Download</downloadUrl>

--- a/test-plugin/pom.xml
+++ b/test-plugin/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <version>${springSecurityVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
             <version>${springSecurityVersion}</version>
         </dependency>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,6 +21,13 @@
             <version>${mule.api.version}</version>
         </dependency>
 
+		<dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gsonVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mule-spring-module</artifactId>
@@ -121,6 +128,12 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
+            <version>${springSecurityVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
             <version>${springSecurityVersion}</version>
             <scope>test</scope>
         </dependency>

--- a/tests/src/test/java/org/mule/extension/spring/test/SpringPluginFunctionalTestCase.java
+++ b/tests/src/test/java/org/mule/extension/spring/test/SpringPluginFunctionalTestCase.java
@@ -16,6 +16,7 @@ import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
     "org.springframework:spring-aop",
     "org.springframework:spring-expression",
     "org.springframework.security:spring-security-core",
+    "org.springframework.security:spring-security-crypto",
     "org.springframework.security:spring-security-config",
     "org.mule.tests:mule-tests-model"
 })


### PR DESCRIPTION
update version for spring and spring security.
exclude gson from transitive dependency
update version test case
- Bump com.google.code.gson to v 2.9.1
- Bump org.springframework to v 5.3.22
- Bump org.springframework.security to 5.7.3

Update crypto dependency to fix the inconsistent code in main and support branches.